### PR TITLE
Revert PMW3389 init to use Legacy firmware load

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -174,7 +174,6 @@ The PMW 3389 is an SPI driven optical sensor, that uses a built in IR LED for su
 |`PMW3389_SPI_DIVISOR`            | (Optional) Sets the SPI Divisor used for SPI communication.                                | _varies_      |
 |`PMW3389_LIFTOFF_DISTANCE`       | (Optional) Sets the lift off distance at run time                                          | `0x02`        |
 |`ROTATIONAL_TRANSFORM_ANGLE`     | (Optional) Allows for the sensor data to be rotated +/- 30 degrees directly in the sensor. | `0`           |
-|`PMW3389_LEGACY_FIRMWARE_UPLOAD` | (Optional) Switches to older, manual upload of firmware, for compatibility.                | _not defined_ |
 
 The CPI range is 50-16000, in increments of 50. Defaults to 2000 CPI.
 

--- a/drivers/sensors/pmw3389.c
+++ b/drivers/sensors/pmw3389.c
@@ -209,17 +209,15 @@ void pmw3389_upload_firmware(void) {
     pmw3389_spi_start();
     spi_write(REG_SROM_Load_Burst | 0x80);
     wait_us(15);
-
-#ifdef PMW3389_LEGACY_FIRMWARE_UPLOAD
+    
+    // Using spi_transmit did not work during testing for the PMW3389
     unsigned char c;
     for (int i = 0; i < FIRMWARE_LENGTH; i++) {
         c = (unsigned char)pgm_read_byte(firmware_data + i);
         spi_write(c);
         wait_us(15);
     }
-#else
-    spi_transmit(firmware_data, sizeof(firmware_data));
-#endif
+
     wait_us(200);
 
     pmw3389_read(REG_SROM_ID);


### PR DESCRIPTION
Sensor failed to respond during testing when using spi_transmit to load firmware so reverting this change to only use the legacy firmware load.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* No official issue but PMW3389 sensor failed to load firmware during testing when using the spi_transmit function instead of the legacy method.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
